### PR TITLE
Adjust loader script based on what's needed for nuget package

### DIFF
--- a/NuGet/Content/XPlot.GoogleCharts.fsx
+++ b/NuGet/Content/XPlot.GoogleCharts.fsx
@@ -1,7 +1,7 @@
 #I __SOURCE_DIRECTORY__
-#r """..\..\..\packages\Google.DataTable.Net.Wrapper.3.1.0.0\lib\Google.DataTable.Net.Wrapper.dll"""
-#r """..\..\..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll"""
-#r """..\..\..\packages\XPlot.GoogleCharts.1.0.0\Lib\Net45\XPlot.GoogleCharts.dll"""
+#r """../../../packages/Google.DataTable.Net.Wrapper.3.1.0.0/lib/Google.DataTable.Net.Wrapper.dll"""
+#r """../../../packages/Newtonsoft.Json.6.0.5/lib/net45/Newtonsoft.Json.dll"""
+#r """../../../packages/XPlot.GoogleCharts.1.0.0/Lib/Net45/XPlot.GoogleCharts.dll"""
 
 open XPlot.GoogleCharts
 


### PR DESCRIPTION
The loader script lands in packages\XPlot.GoogleCharts.1.0.0\Content, adjust the references to parallel projects appropriately
