### PR TITLE
Set HTML charset attribute to UTF-8 in template

### DIFF
--- a/src/XPlot.GoogleCharts/Main.fs
+++ b/src/XPlot.GoogleCharts/Main.fs
@@ -160,6 +160,7 @@ module Templates =
         """<!DOCTYPE html>
     <html>
         <head>
+            <meta charset="UTF-8">
             <meta http-equiv="X-UA-Compatible" content="IE=edge" />
             <title>Google Chart</title>
             <script type="text/javascript" src="https://www.google.com/jsapi"></script>


### PR DESCRIPTION
Currently no charset attribute is set, so the browser assumes Windows-1252 and the text is  most likely garbled if you use non-ascii chars

[FsLab](https://github.com/fslaborg/FsLab/blob/master/src/FsLab.fsx) uses `File.WriteAllText` for HTML-Preview (which encodes Text as UTF-8).

IMHO this is a good default